### PR TITLE
feat: 🎸 Added debug option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "pino-openobserve",
+  "name": "@openobserve/pino-openobserve",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "@openobserve/pino-openobserve",
+      "version": "0.0.3",
+      "license": "Apache-2.0",
       "dependencies": {
         "url": "^0.11.3"
       }


### PR DESCRIPTION
I think you should not spam the console with messages about the successful delivery of the log. To do this, I added the "showDebug" flag to the options, which is enabled by default, which will not change the behavior of the module now, but will allow the developer to disable the message about successful delivery. Error messages will still be displayed regardless of the flag