### PR TITLE
Add control over logging verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The transport accepts an options object with the following properties:
 | auth | Yes | `{ username: "", password: "" }` | An object with `username` and `password` properties for authenticating with the Openobserve server |
 | batchSize | No | `100` | The number of logs to include in each batch. |
 | timeThreshold | No | `300000` (5 mins) | The interval, in milliseconds, at which logs should be sent. |
+| silentSuccess | No | false | A boolean indicating whether to suppress successful operation messages. |
+| silentError | No | false | A boolean indicating whether to suppress error messages. |
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ class OpenobserveTransport extends Transform {
       },
       batchSize: 100,
       timeThreshold: 5 * 60 * 1000,
+      silentSuccess: false,
+      silentError: false,
     };
 
     this.options = { ...defaultOptions, ...options };
@@ -84,7 +86,7 @@ class OpenobserveTransport extends Transform {
       return;
     }
 
-    const { auth } = this.options;
+    const { auth, silentSuccess, silentError } = this.options;
     const bulkLogs = this.logs.splice(0, this.options.batchSize).join('');
 
     this.apiCallInProgress = true;
@@ -99,13 +101,13 @@ class OpenobserveTransport extends Transform {
     })
       .then(async response => {
         if (response.ok) {
-          console.log('successful: ', await response.json());
+          if (!silentSuccess) console.log('successful: ', await response.json());
         } else {
-          console.error('Failed to send logs:', response.status, response.statusText);
+          if (!silentError) console.error('Failed to send logs:', response.status, response.statusText);
         }
       })
       .catch(error => {
-        console.error('Failed to send logs:', error);
+        if (!silentError) console.error('Failed to send logs:', error);
       })
       .finally(() => {
         this.apiCallInProgress = false;


### PR DESCRIPTION
This pull request introduces two new options _silentSuccess_ and _silentError_, allowing users to control the verbosity of console logs for successful operations and error messages separately.

This enhancement aims to provide users with more flexibility in managing log outputs, particularly in production environments where console logs can be verbose or when debugging specific issues.

These changes are fully backward compatible. Existing implementations without the new options will function as before, with both success and error logs being shown by default.


