### PR TITLE
fix: Pino target compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,33 +39,20 @@ The transport accepts an options object with the following properties:
 
 ## Usage
 
-You can use the transport by importing it directly, or by passing the package name as the target.
+You can use the transport by passing the package name as target, or by importing it directly.
 
-### Direct import
-
-The way you import the `pino` and `@openobserve/pino-openobserve` packages depends on whether you're using `import` or `require`. 
-
-Using `import`:
-
+### Using package name (Recommended)
 ```javascript
-import pino from 'pino';
-import OpenobserveTransport from '@openobserve/pino-openobserve';
-```
-
-Using `require`:
-
-```javascript
+// using require
 const pino = require('pino');
-const OpenobserveTransport = require('@openobserve/pino-openobserve');
-```
 
-After importing the necessary packages, you can use this transport with Pino like this:
+// using import
+import pino from 'pino';
 
-```javascript
 const logger = pino({
   level: 'info',
   transport: {
-    target: OpenobserveTransport,
+    target: '@openobserve/pino-openobserve',
     options: {
       url: 'https://your-openobserve-server.com',
       organization: 'your-organization',
@@ -82,18 +69,23 @@ logger.info('Hello, world!');
 logger.info({ lang: 'js', code: 'Node.js' }, 'Logging with JSON');
 ```
 
-### Using package name
+### Direct import
+
+The way you import the `pino` and `@openobserve/pino-openobserve` packages depends on whether you're using `import` or `require`. 
+
 ```javascript
 // using require
 const pino = require('pino');
+const OpenobserveTransport = require('@openobserve/pino-openobserve').OpenobserveTransport;
 
 // using import
 import pino from 'pino';
+import { OpenobserveTransport } from '@openobserve/pino-openobserve';
 
 const logger = pino({
   level: 'info',
   transport: {
-    target: '@openobserve/pino-openobserve',
+    target: OpenobserveTransport,
     options: {
       url: 'https://your-openobserve-server.com',
       organization: 'your-organization',

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The transport accepts an options object with the following properties:
 
 ## Usage
 
+You can use the transport by importing it directly, or by passing the package name as the target.
+
+### Direct import
+
 The way you import the `pino` and `@openobserve/pino-openobserve` packages depends on whether you're using `import` or `require`. 
 
 Using `import`:
@@ -78,7 +82,35 @@ logger.info('Hello, world!');
 logger.info({ lang: 'js', code: 'Node.js' }, 'Logging with JSON');
 ```
 
-In this example, the second `logger.info` call logs a JSON object containing the properties `lang` and `code`, along with the message 'Logging with JSON'. This is a common way to include structured data in your logs when using Pino.
+### Using package name
+```javascript
+// using require
+const pino = require('pino');
+
+// using import
+import pino from 'pino';
+
+const logger = pino({
+  level: 'info',
+  transport: {
+    target: '@openobserve/pino-openobserve',
+    options: {
+      url: 'https://your-openobserve-server.com',
+      organization: 'your-organization',
+      streamName: 'your-stream',
+      auth: {
+        username: 'your-username',
+        password: 'your-password',
+      },
+    },
+  },
+});
+
+logger.info('Hello, world!');
+logger.info({ lang: 'js', code: 'Node.js' }, 'Logging with JSON');
+```
+
+In the above examples, the second `logger.info` call logs a JSON object containing the properties `lang` and `code`, along with the message 'Logging with JSON'. This is a common way to include structured data in your logs when using Pino.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Transform, TransformCallback } from 'stream';
-import * as url from 'url';
+import { Transform, TransformCallback } from "stream";
+import * as url from "url";
 
 /**
  * Options for the basic auth
@@ -81,7 +81,7 @@ interface TransportOptions {
   silentError?: boolean;
 }
 
-class OpenobserveTransport extends Transform {
+export class OpenobserveTransport extends Transform {
   private options: TransportOptions;
   private logs: string[];
   private timer: NodeJS.Timeout | null;
@@ -100,15 +100,21 @@ class OpenobserveTransport extends Transform {
 
     this.options = { ...defaultOptions, ...options } as TransportOptions;
 
-    if (!this.options.url || !this.options.organization || !this.options.streamName) {
-      throw new Error('OpenObserve Pino: Missing required options: url, organization, or streamName');
+    if (
+      !this.options.url ||
+      !this.options.organization ||
+      !this.options.streamName
+    ) {
+      throw new Error(
+        "OpenObserve Pino: Missing required options: url, organization, or streamName"
+      );
     }
 
     this.logs = [];
     this.timer = null;
     this.apiCallInProgress = false;
 
-    process.on('beforeExit', () => {
+    process.on("beforeExit", () => {
       if (this.logs.length > 0 && !this.apiCallInProgress) {
         this.sendLogs();
       }
@@ -120,11 +126,19 @@ class OpenobserveTransport extends Transform {
   private createApiUrl(): string {
     const { url: baseUrl, organization, streamName } = this.options;
     const parsedUrl = url.parse(baseUrl);
-    const path = parsedUrl.pathname ? (parsedUrl.pathname.endsWith('/') ? parsedUrl.pathname.slice(0, -1) : parsedUrl.pathname) : '';
+    const path = parsedUrl.pathname
+      ? parsedUrl.pathname.endsWith("/")
+        ? parsedUrl.pathname.slice(0, -1)
+        : parsedUrl.pathname
+      : "";
     return `${parsedUrl.protocol}//${parsedUrl.host}${path}/api/${organization}/${streamName}/_multi`;
   }
 
-  _transform(log: any, encoding: BufferEncoding, callback: TransformCallback): void {
+  _transform(
+    log: any,
+    encoding: BufferEncoding,
+    callback: TransformCallback
+  ): void {
     this.logs.push(log);
     this.scheduleSendLogs();
     callback();
@@ -149,29 +163,34 @@ class OpenobserveTransport extends Transform {
     }
 
     const { auth, silentSuccess, silentError } = this.options;
-    const bulkLogs = this.logs.splice(0, this.options.batchSize!).join('');
+    const bulkLogs = this.logs.splice(0, this.options.batchSize!).join("");
 
     this.apiCallInProgress = true;
 
     try {
       const response = await fetch(this.apiUrl, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Authorization': `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString('base64')}`,
-          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(
+            `${auth.username}:${auth.password}`
+          ).toString("base64")}`,
+          "Content-Type": "application/json",
         },
         body: bulkLogs,
       });
 
       if (response.ok) {
-        if (!silentSuccess) console.log('successful: ', await response.json());
+        if (!silentSuccess) console.log("successful: ", await response.json());
       } else {
-        if (!silentError) console.error('Failed to send logs:', response.status, response.statusText);
+        if (!silentError)
+          console.error(
+            "Failed to send logs:",
+            response.status,
+            response.statusText
+          );
       }
-
-
     } catch (error) {
-      if (!silentError) console.error('Failed to send logs:', error);
+      if (!silentError) console.error("Failed to send logs:", error);
     } finally {
       this.apiCallInProgress = false;
       this.scheduleSendLogs();
@@ -179,4 +198,4 @@ class OpenobserveTransport extends Transform {
   }
 }
 
-export default OpenobserveTransport;
+export default (opts: TransportOptions) => new OpenobserveTransport(opts);

--- a/tests/OpenobserveTransport.test.ts
+++ b/tests/OpenobserveTransport.test.ts
@@ -1,4 +1,4 @@
-import OpenobserveTransport from "../src/index";
+import { OpenobserveTransport } from "../src/index";
 
 describe("OpenobserveTransport", () => {
   /**
@@ -49,7 +49,9 @@ describe("OpenobserveTransport", () => {
     // Attempt to instantiate OpenobserveTransport with missing options
     expect(() => {
       new OpenobserveTransport({} as any); // This should cause an error due to missing required fields
-    }).toThrow("OpenObserve Pino: Missing required options: url, organization, or streamName");
+    }).toThrow(
+      "OpenObserve Pino: Missing required options: url, organization, or streamName"
+    );
   });
 
   /**
@@ -63,7 +65,9 @@ describe("OpenobserveTransport", () => {
 
     expect(() => {
       new OpenobserveTransport(incompleteOptions); // Instantiate the class
-    }).toThrow("OpenObserve Pino: Missing required options: url, organization, or streamName");
+    }).toThrow(
+      "OpenObserve Pino: Missing required options: url, organization, or streamName"
+    );
   });
 
   /**
@@ -78,7 +82,9 @@ describe("OpenobserveTransport", () => {
     // Attempt to instantiate OpenobserveTransport with missing 'streamName' option
     expect(() => {
       new OpenobserveTransport(incompleteOptions); // Instantiate the class
-    }).toThrow("OpenObserve Pino: Missing required options: url, organization, or streamName");
+    }).toThrow(
+      "OpenObserve Pino: Missing required options: url, organization, or streamName"
+    );
   });
 
   /**
@@ -104,7 +110,10 @@ describe("OpenobserveTransport", () => {
    */
   it("should correctly create API URL", () => {
     // Spy on the private 'createApiUrl' method to check if it was called
-    const spyCreateApiUrl = jest.spyOn(OpenobserveTransport.prototype as any, "createApiUrl");
+    const spyCreateApiUrl = jest.spyOn(
+      OpenobserveTransport.prototype as any,
+      "createApiUrl"
+    );
 
     // Instantiate the class
     transport = new OpenobserveTransport(validOptions);
@@ -136,7 +145,10 @@ describe("OpenobserveTransport", () => {
     );
 
     // Spy on the 'scheduleSendLogs' method to check if it was called
-    const scheduleSendLogsSpy = jest.spyOn(transport as any, "scheduleSendLogs");
+    const scheduleSendLogsSpy = jest.spyOn(
+      transport as any,
+      "scheduleSendLogs"
+    );
 
     // Mock the callback passed to _transform
     const callback = jest.fn();
@@ -275,7 +287,9 @@ describe("OpenobserveTransport", () => {
     );
 
     // Verify that the console.log function was called with a success message
-    expect(console.log).toHaveBeenCalledWith("successful: ", { statusText: "ok" });
+    expect(console.log).toHaveBeenCalledWith("successful: ", {
+      statusText: "ok",
+    });
   });
 
   /**
@@ -315,7 +329,10 @@ describe("OpenobserveTransport", () => {
     await transport["sendLogs"]();
 
     // Verify that the console.error function was called with an error message
-    expect(console.error).toHaveBeenCalledWith("Failed to send logs:", expect.any(Error));
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to send logs:",
+      expect.any(Error)
+    );
   });
 
   /**


### PR DESCRIPTION
# What?

Use a factory as default export to follow pino transport strategy and make this lib working with other transformers like pino-http.

Thus one could be using it as:

```javascript
// using require
const pino = require('pino');

// using import
import pino from 'pino';

const logger = pino({
  level: 'info',
  transport: {
    target: '@openobserve/pino-openobserve',
    options: {
      url: 'https://your-openobserve-server.com',
      organization: 'your-organization',
      streamName: 'your-stream',
      auth: {
        username: 'your-username',
        password: 'your-password',
      },
    },
  },
});

logger.info('Hello, world!');
logger.info({ lang: 'js', code: 'Node.js' }, 'Logging with JSON');
```

## Why?
Fixes following issues:
- #6
- #5

## How?
Replace default export of the lib to a factory, yet keeping the original class export as named export.
Updated the README file to document the recommended usage.